### PR TITLE
Fix table processor when no header present

### DIFF
--- a/src/processors.py
+++ b/src/processors.py
@@ -28,19 +28,29 @@ class TableProcessor(IContentProcessor):
     def process(self, content: str) -> str:
         if "<table>" not in content:
             return content
-            
+
         content = content.replace('<table>', '').replace('</table>', '').strip()
         lines = [line.strip() for line in content.split('\n') if line.strip()]
-        
+
         html_parts = ['<table class="content-table">']
-        
+        tbody_open = False
+
         for line in lines:
             if line.startswith('<thead>'):
                 html_parts.append(self._process_header(line))
+                tbody_open = True  # _process_header opens <tbody>
+            elif line.startswith('<tbody>') or line.startswith('</tbody>'):
+                # Skip explicit tbody tags from the input
+                continue
             elif '[[' in line and ']]' in line:
+                if not tbody_open:
+                    html_parts.append('<tbody>')
+                    tbody_open = True
                 html_parts.append(self._process_row(line))
-        
-        html_parts.extend(['</tbody>', '</table>'])
+
+        if tbody_open:
+            html_parts.extend(['</tbody>'])
+        html_parts.append('</table>')
         table_html = '\n'.join(html_parts)
         # Envelopper le tableau dans un div responsive
         return f'<div class="table-responsive">\n{table_html}\n</div>'


### PR DESCRIPTION
## Summary
- ensure TableProcessor handles tables without header rows

## Testing
- `python -m main.py input/input.html output/test_output.html --config configs/config.yml --log-config configs/logging_config.yml` *(fails: ModuleNotFoundError: No module named 'yaml')*
- `python -m py_compile src/processors.py`

------
https://chatgpt.com/codex/tasks/task_e_68417f6adbdc832689db1e59fb014ac6