### PR TITLE
Fix html_converter asset verification function

### DIFF
--- a/src/html_converter.py
+++ b/src/html_converter.py
@@ -485,10 +485,16 @@ class HTMLConverter:
         except ValueError:
             return str(to_path)
         
-    def _verify_assets_structure(self, output_dir: Path) -> None:
-        """Vérifie que la structure des assets est correcte."""
+    def _verify_assets_structure(self, output_dir: Path) -> List[str]:
+        """Vérifie que la structure des assets est correcte.
+
+        Returns:
+            List[str]: liste des fichiers manquants.
+        """
         required_dirs = ['css', 'js', 'images']
         assets_dir = output_dir / 'assets'
+
+        missing_files: List[str] = []
         
         for dir_name in required_dirs:
             dir_path = assets_dir / dir_name
@@ -509,3 +515,6 @@ class HTMLConverter:
                 file_path = dir_path / file_name
                 if not file_path.exists():
                     self.logger.warning(f"Fichier d'asset manquant : {file_path}")
+                    missing_files.append(str(file_path))
+
+        return missing_files


### PR DESCRIPTION
## Summary
- close loops in `_verify_assets_structure`
- collect missing assets and return the list

## Testing
- `python -m py_compile src/html_converter.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684180a0a1e48326a417ed43ddf43573