### PR TITLE
Add pytest tests for title processing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Contribuer
+
+Ce projet utilise **pytest** pour les tests automatisés.
+
+## Exécuter les tests
+
+1. Installez les dépendances requises :
+   ```sh
+   pip install -r requirements.txt
+   ```
+2. Lancez ensuite pytest à la racine du dépôt :
+   ```sh
+   pytest
+   ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+addopts = -vv

--- a/tests/test_process_titles.py
+++ b/tests/test_process_titles.py
@@ -1,0 +1,15 @@
+import pytest
+from src.html_converter import HTMLConverter
+
+@pytest.fixture
+def converter():
+    return HTMLConverter(config_path="configs/config.yml")
+
+
+def test_process_titles_basic(converter):
+    html = "<h1>Title 1</h1><h2>Title 2</h2><h3>Title 3</h3>"
+    processed, titles = converter.process_titles(html)
+
+    assert [t.level for t in titles] == [1, 2, 3]
+    assert [t.text for t in titles] == ["Title 1", "Title 2", "Title 3"]
+    assert [t.id for t in titles] == ["section1", "section2", "section3"]


### PR DESCRIPTION
## Summary
- add CONTRIBUTING with pytest instructions
- set up pytest config
- test `HTMLConverter.process_titles`

## Testing
- `pytest -q` *(fails: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_684180a3640c83269bd163c445676433